### PR TITLE
option DeadСanTalkDuringTasks and optimizations

### DIFF
--- a/bot/Game.cs
+++ b/bot/Game.cs
@@ -41,6 +41,8 @@ namespace Impostor.Plugins.ImpostorCord.Discord
     public class Player
     {
         public bool isDead = false;
+        public bool isMute = false;
+        public bool isDeaf = false;
         public DiscordMember uid;
         public Game game;
         public Player(Game game) {

--- a/bot/Game.cs
+++ b/bot/Game.cs
@@ -6,18 +6,7 @@ namespace Impostor.Plugins.ImpostorCord.Discord
     {
         public DiscordChannel gameStartingChannel; // storing the channel that the game started in
         public DiscordChannel voiceChannel;
-        public Player[] players = {new Player(), // red
-            new Player(), // blue
-            new Player(), // green
-            new Player(), // pink
-            new Player(), // orange
-            new Player(), // yellow
-            new Player(), // black
-            new Player(), // white
-            new Player(), // purple
-            new Player(), // brown
-            new Player(), // cyan
-            new Player()}; //lime
+        public Player[] players;
         public bool noVC()
         {
             if (voiceChannel == null)
@@ -29,10 +18,33 @@ namespace Impostor.Plugins.ImpostorCord.Discord
                 return false;
             }
         }
+        public bool DeadСanTalkDuringTasks = true;
+
+        public Game(){
+            players = new [] {
+                //TODO optimize
+                new Player(this), // red
+                new Player(this), // blue
+                new Player(this), // green
+                new Player(this), // pink
+                new Player(this), // orange
+                new Player(this), // yellow
+                new Player(this), // black
+                new Player(this), // white
+                new Player(this), // purple
+                new Player(this), // brown
+                new Player(this), // cyan
+                new Player(this)  // lime
+            };
+        }
     }
     public class Player
     {
         public bool isDead = false;
         public DiscordMember uid;
+        public Game game;
+        public Player(Game game) {
+            this.game = game;
+        }
     }
 }

--- a/bot/bot.cs
+++ b/bot/bot.cs
@@ -16,16 +16,21 @@ namespace Impostor.Plugins.ImpostorCord.Discord
         public static DiscordClient client;
         static CommandsNextExtension commands;
         static private WebProxy _proxy;
-        static private ICredentials credentials;
-        public Bot(string token, string prefix, string proxy,string proxyUserName,string proxyPassword)
+        public static Config config;
+        public Bot(Config _config)
         {
-            credentials = new NetworkCredential(proxyUserName,proxyPassword);
-            _proxy = new WebProxy(proxy);
-            _proxy.Credentials = credentials;
-            MainAsync(token).ConfigureAwait(false).GetAwaiter().GetResult();
+            config=_config;
+
+            if (config.BotProxyEnabled)
+            {
+                _proxy = new WebProxy(config.BotProxyAddress);
+                _proxy.Credentials = new NetworkCredential(config.BotProxyUsername, config.BotProxyPassword);;
+            }
+
+            MainAsync(config.Token).ConfigureAwait(false).GetAwaiter().GetResult();
             commands = client.UseCommandsNext(new CommandsNextConfiguration
             {
-                StringPrefixes = new string[] { prefix }
+                StringPrefixes = new string[] { config.Prefix }
             });
             commands.RegisterCommands<MyCommands>();
         }

--- a/bot/bot.cs
+++ b/bot/bot.cs
@@ -69,9 +69,8 @@ namespace Impostor.Plugins.ImpostorCord.Discord
 
             await client.ConnectAsync();
         }
-        public static async Task Tasks(string code,int delay)
+        public static async Task Tasks(string code)
         {
-            await Task.Delay(TimeSpan.FromSeconds(delay));
             foreach (Player player in games[code].players)
             {
                 if (player.uid != null)

--- a/bot/commands.cs
+++ b/bot/commands.cs
@@ -187,5 +187,35 @@ namespace Impostor.Plugins.ImpostorCord.Discord
                 await ctx.RespondAsync("Invalid color!");
             }
         }
+        [Command("deadtalk")]
+        [Aliases("dt")]
+        public async Task deadtalk(CommandContext ctx, bool deadCanTalk)
+        {
+
+            if (ctx.Member?.VoiceState?.Channel != null)
+            {
+                bool gameFound = false;
+                foreach (KeyValuePair<string, Game> game in Bot.games)
+                {
+                    if (game.Value.voiceChannel == ctx.Member.VoiceState.Channel)
+                    {
+                        gameFound = true;
+                        game.Value.DeadСanTalkDuringTasks = deadCanTalk;
+
+                        await ctx.RespondAsync($"Dead players can talk during tasks in game `{game.Key}` is "+ (deadCanTalk ?"*Enabled*" :"*Disabled*"));
+                        break;
+                    }
+                }
+                if (!gameFound)
+                {
+                    await ctx.RespondAsync("could not find a game in that voice channel");
+                }
+            }
+            else
+            {
+                await ctx.RespondAsync("you aren't in a voice channel!");
+            }
+
+        }
     }
 }

--- a/bot/commands.cs
+++ b/bot/commands.cs
@@ -28,6 +28,7 @@ namespace Impostor.Plugins.ImpostorCord.Discord
                             gameFound = true;
                             Bot.games[game.Key].players[colorIndex].uid = ctx.Member;
                             await ctx.RespondAsync($"{ctx.Member.Mention} is joined as {colors[colorIndex]}");
+                            break;
                         }
                     }
                     if (!gameFound)
@@ -133,6 +134,7 @@ namespace Impostor.Plugins.ImpostorCord.Discord
                             gameFound = true;
                             Bot.games[game.Key].players[colorIndex].uid = member;
                             await ctx.RespondAsync($"{member.Mention} is joined as {colors[colorIndex]}");
+                            break;
                         }
                     }
                     if (!gameFound)
@@ -167,6 +169,7 @@ namespace Impostor.Plugins.ImpostorCord.Discord
                             gameFound = true;
                             Bot.games[game.Key].players[colorIndex].uid = null;
                             await ctx.RespondAsync($"Cleared memberdata from {colors[colorIndex]}");
+                            break;
                         }
                     }
                     if (!gameFound)

--- a/config.impostorCord.json
+++ b/config.impostorCord.json
@@ -5,4 +5,6 @@
     "botProxyAddress": "",
     "botProxyUsername": "",
     "botProxyPassword": ""
+
+    ,"extraSecondsOfTalkAfterMeeting": 10
 }

--- a/config.impostorCord.json
+++ b/config.impostorCord.json
@@ -7,4 +7,5 @@
     "botProxyPassword": ""
 
     ,"extraSecondsOfTalkAfterMeeting": 10
+    ,"deadСanTalkDuringTasks": true
 }

--- a/handlers/EventHandler.cs
+++ b/handlers/EventHandler.cs
@@ -54,7 +54,7 @@ namespace Impostor.Plugins.ImpostorCord.Handlers
         [EventListener]
         public void OnGameCreated(IGameCreatedEvent e)
         {
-            Bot.games.Add(e.Game.Code.Code,new Game());
+            Bot.games.Add(e.Game.Code.Code,new Game {DeadСanTalkDuringTasks=Bot.config.DeadСanTalkDuringTasks} );
         }
         [EventListener]
         public void OnGameDestroyed(IGameDestroyedEvent e)

--- a/handlers/EventHandler.cs
+++ b/handlers/EventHandler.cs
@@ -26,17 +26,23 @@ namespace Impostor.Plugins.ImpostorCord.Handlers
                     Bot.games[e.Game.Code.Code].players[player.Character.PlayerInfo.ColorId].isDead = true;
                 }
             }
-            await Bot.Meeting(e.Game.Code.Code); 
+            await Bot.Meeting(e.Game.Code.Code);
         }
         [EventListener]
         public async void OnMeetingEnded(IMeetingEndedEvent e)
         {
-            await Bot.Tasks(e.Game.Code.Code, 10);
+            if(Bot.config.ExtraSecondsOfTalkAfterMeeting>0)
+            {
+                await System.Threading.Tasks.Task.Delay(System.TimeSpan.FromSeconds(Bot.config.ExtraSecondsOfTalkAfterMeeting));
+            }
+
+            if(e.Game.GameState==Api.Innersloth.GameStates.Started)
+                await Bot.Tasks(e.Game.Code.Code);
         }
         [EventListener]
         public async void OnGameStarted(IGameStartedEvent e)
         {
-            await Bot.Tasks(e.Game.Code.Code, 0);
+            await Bot.Tasks(e.Game.Code.Code);
 
         }
 

--- a/main.cs
+++ b/main.cs
@@ -51,5 +51,7 @@ namespace Impostor.Plugins.ImpostorCord
         [JsonPropertyName("botProxyPassword")]
         public string BotProxyPassword { get; set; }
 
+        [JsonPropertyName("extraSecondsOfTalkAfterMeeting")]
+        public uint ExtraSecondsOfTalkAfterMeeting { get; set; }
     }
 }

--- a/main.cs
+++ b/main.cs
@@ -53,5 +53,9 @@ namespace Impostor.Plugins.ImpostorCord
 
         [JsonPropertyName("extraSecondsOfTalkAfterMeeting")]
         public uint ExtraSecondsOfTalkAfterMeeting { get; set; }
+
+        [JsonPropertyName("deadСanTalkDuringTasks")]
+        public bool DeadСanTalkDuringTasks { get; set; }
+
     }
 }

--- a/main.cs
+++ b/main.cs
@@ -18,21 +18,15 @@ namespace Impostor.Plugins.ImpostorCord
     {
         private readonly ILogger<ImpostorCord> _logger;
         private Bot _bot;
+
+        private readonly Config config;
         public ImpostorCord(ILogger<ImpostorCord> logger, IEventManager eventManager)
         {
             _logger = logger;
             string configFile = File.ReadAllText("./config.impostorCord.json");
-            var config = JsonSerializer.Deserialize<Config>(configFile);
-            string proxyAddress;
-            if (!config.BotProxyEnabled)
-            {
-                proxyAddress = null;
-            }
-            else
-            {
-                proxyAddress = config.BotProxyAddress;
-            }
-            _bot = new Bot(config.Token, config.Prefix, proxyAddress, config.BotProxyUsername, config.BotProxyPassword);
+            config = JsonSerializer.Deserialize<Config>(configFile);
+
+            _bot = new Bot(config);
             eventManager.RegisterListener(new GameEventListener(logger, _bot));
         }
 


### PR DESCRIPTION
+ public access to config via `Bot`
+ configurable extra seconds of talk after meeting via config
+ configurable option `DeadСanTalkDuringTasks` globally and for the specified game  via command `deadtalk`
+ player voice state caching
+ Prevention of crash if the bot does not have mute/deaf permission